### PR TITLE
Fix crash when selection is empty

### DIFF
--- a/libqite/qite.cpp
+++ b/libqite/qite.cpp
@@ -163,7 +163,7 @@ bool InteractiveText::eventFilter(QObject *obj, QEvent *event)
             cursor.setPosition(docLPos);
             cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor);
             const auto &selection = cursor.selectedText();
-            if (selection[0] == QChar::ObjectReplacementCharacter) {
+            if ((!selection.isEmpty()) && (selection[0] == QChar::ObjectReplacementCharacter)) {
 
                 auto  format            = cursor.charFormat();
                 auto  elementId         = format.property(InteractiveTextFormat::Id).toUInt();


### PR DESCRIPTION
<details>
  <summary>Crash information</summary>

```
[20210827 10:47:57] F:ASSERT: "uint(i) < uint(size())" in file /usr/include/qt5/QtCore/qstring.h, line 1074 (/usr/include/qt5/QtCore/qstring.h:1074, unknown)

Thread 1 "psi-plus" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
49        return ret;
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:49
#1  0x00007ffff5ef8538 in __GI_abort () at abort.c:79
#2  0x00007ffff75fc131 in qt_message_fatal (message=<synthetic pointer>..., context=...) at global/qlogging.cpp:1914
#3  QMessageLogger::fatal (this=this@entry=0x7fffffffd598, msg=msg@entry=0x7ffff790bea0 "ASSERT: \"%s\" in file %s, line %d") at global/qlogging.cpp:893
#4  0x00007ffff75fb528 in qt_assert (assertion=<optimized out>, file=<optimized out>, line=<optimized out>) at global/qglobal.cpp:3358
#5  0x0000555555a1ec35 in QString::operator[] (this=0x7fffffffd638, i=0) at /usr/include/qt5/QtCore/qstring.h:1074
#6  0x0000555555b81657 in InteractiveText::eventFilter (this=0x5555568127c0, obj=0x5555570e6930, event=0x7fffffffd7e0) at /usr/src/debug/psi-plus-snapshots-1.5.1543/3rdparty/qite/libqite/qite.cpp:166
#7  0x00007ffff7829423 in QCoreApplicationPrivate::sendThroughObjectEventFilters (event=<optimized out>, receiver=<optimized out>) at kernel/qcoreapplication.cpp:1190
#8  QCoreApplicationPrivate::sendThroughObjectEventFilters (receiver=receiver@entry=0x5555570e6930, event=event@entry=0x7fffffffd7e0) at kernel/qcoreapplication.cpp:1179
#9  0x00007ffff66d1b0e in QApplicationPrivate::notify_helper (this=this@entry=0x555556475160, receiver=receiver@entry=0x5555570e6930, e=e@entry=0x7fffffffd7e0) at kernel/qapplication.cpp:3626
#10 0x00007ffff66daa98 in QApplication::notify (this=<optimized out>, receiver=<optimized out>, e=0x7fffffffdb30) at kernel/qapplication.cpp:3101
#11 0x00007ffff78296ba in QCoreApplication::notifyInternal2 (receiver=0x5555570e6a50, event=0x7fffffffdb30) at kernel/qcoreapplication.cpp:1064
#12 0x00007ffff66d8123 in QApplicationPrivate::sendMouseEvent (receiver=receiver@entry=0x5555570e6a50, event=event@entry=0x7fffffffdb30, alienWidget=alienWidget@entry=0x5555570e6a50, nativeWidget=0x5555570b51d0, 
    buttonDown=<optimized out>, lastMouseReceiver=..., spontaneous=true, onlyDispatchEnterLeave=false) at kernel/qapplication.cpp:2614
#13 0x00007ffff672d16c in QWidgetWindow::handleMouseEvent (this=0x55555719f770, event=0x7fffffffddf0) at kernel/qwidgetwindow.cpp:683
#14 0x00007ffff67303e5 in QWidgetWindow::event (this=0x55555719f770, event=0x7fffffffddf0) at kernel/qwidgetwindow.cpp:300
#15 0x00007ffff66d1b1f in QApplicationPrivate::notify_helper (this=<optimized out>, receiver=0x55555719f770, e=0x7fffffffddf0) at kernel/qapplication.cpp:3632
#16 0x00007ffff78296ba in QCoreApplication::notifyInternal2 (receiver=0x55555719f770, event=0x7fffffffddf0) at kernel/qcoreapplication.cpp:1064
#17 0x00007ffff6f7ae43 in QGuiApplicationPrivate::processMouseEvent (e=0x55555715c4b0) at kernel/qguiapplication.cpp:2275
#18 0x00007ffff6f50c6c in QWindowSystemInterface::sendWindowSystemEvents (flags=flags@entry=...) at kernel/qwindowsysteminterface.cpp:1169
#19 0x00007ffff2838c7a in xcbSourceDispatch (source=<optimized out>) at qxcbeventdispatcher.cpp:105
#20 0x00007ffff534f6bb in g_main_dispatch (context=0x7fffec005000) at ../glib/gmain.c:3337
#21 g_main_context_dispatch (context=0x7fffec005000) at ../glib/gmain.c:4055
#22 0x00007ffff534f968 in g_main_context_iterate (context=context@entry=0x7fffec005000, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4131
#23 0x00007ffff534fa1f in g_main_context_iteration (context=0x7fffec005000, may_block=may_block@entry=1) at ../glib/gmain.c:4196
#24 0x00007ffff7881140 in QEventDispatcherGlib::processEvents (this=0x5555565198c0, flags=...) at kernel/qeventdispatcher_glib.cpp:423
#25 0x00007ffff78280eb in QEventLoop::exec (this=this@entry=0x7fffffffe120, flags=..., flags@entry=...) at ../../include/QtCore/../../src/corelib/global/qflags.h:69
#26 0x00007ffff7830330 in QCoreApplication::exec () at ../../include/QtCore/../../src/corelib/global/qflags.h:121
#27 0x0000555555a22f72 in main (argc=1, argv=0x7fffffffe348) at /usr/src/debug/psi-plus-snapshots-1.5.1543/src/main.cpp:586
```
</details>